### PR TITLE
add handling overwriting conflict files

### DIFF
--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -66,13 +66,14 @@ app
   .option('-b, --debug-brk [port]', 'start in remote debug mode, wait for debugger connect')
   .option('-m, --mock', 'run in mock mode')
   .action(execute(project.test));
-  
-app 
+
+app
   .command('generate-test [directory]')
   .description('Generate the test template')
   .option('-p, --path-name [path]', 'a sepecific path of the api, also suppport regular expression')
   .option('-f, --test-module <module>', 'one of: ' + testmodules)
   .option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
+  .option('-o, --force', 'allow overwriting of all existing test files matching those generated', false)
   .action(execute(project.generateTest));
 
 app.parse(process.argv);

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -39,8 +39,6 @@ var FRAMEWORKS = {
   sails:   { source: 'sails' }
 };
 
-var OVERWRITES = ['none', 'all', 'prompt'];
-
 var ASSERTIONTYPES = ['expect', 'should', 'assert'];
 var TESTMODULES = ['supertest', 'request'];
 
@@ -469,28 +467,50 @@ function testGenerate(directory, options, cb) {
             assertionFormat: assertionFormat
           };
           var finalResult = template.testGen(result, config);
-          var conflicts;
+          var existingFiles = fs.readdirSync(path.join(directory, 'test'));
 
-          if (!overwriteAll) {
-            conflicts = findConflictFiles(directory, finalResult);
+          async.filterSeries(finalResult, function(file, cb) {
+            if (overwriteAll) {
+              cb(true);
+            } else {
+              if (lodash.includes(existingFiles, file.name)) {
+                var prompt = util.format('Conflict on %s:', file.name);
+                var question = {type: 'expand', message: prompt, name: 'overwrite', choices: [
+                  {
+                    key: "y",
+                    name: "Overwrite",
+                    value: "overwrite"
+                  },
+                  {
+                    key: "a",
+                    name: "Overwrite this one and all next",
+                    value: "overwrite_all"
+                  },
+                  {
+                    key: 'n',
+                    name: 'Overwrite none',
+                    value: 'overwrite_none'
+                  }
+                ]};
 
-            if (conflicts.length > 0) {
-              var message = util.format('Found %d conflicted file(s). %s',
-                conflicts.length, 'How would you like to overwrite?');
-
-              var questions = [
-                { name: 'overwrite', message: message, type: 'list', choices: OVERWRITES }
-              ];
-
-              cli.requireAnswers(questions, function(results) {
-                  writeTestFiles(directory, finalResult, conflicts, results.overwrite, cb);
-              });
+                inquirer.prompt(question, function(answers) {
+                  if (answers.overwrite === 'overwrite') {
+                    cb(true);
+                  } else if (answers.overwrite === 'overwrite_all') {
+                    overwriteAll = true;
+                    cb(true);
+                  } else {
+                    cb(false);
+                  }
+                });
+              }
             }
-          }
+          }, function(filteredResult) {
 
-          if (overwriteAll || conflicts.length === 0) {
-            writeTestFiles(directory, finalResult, null, OVERWRITES[1], cb);
-          }
+            async.each(filteredResult, function(file, cb) {
+              fs.outputFile(path.join(directory, '/test', file.name), file.test, cb);
+            }, cb);
+          });
         });
       });
     });
@@ -506,71 +526,3 @@ function installDependencies(directory, message, cb) {
     cb(null, message);
   });
 }
-
-function writeTestFiles(directory, tests, conflicted, overwrite, callback) {
-
-  if (overwrite === OVERWRITES[2]) { // prompt on conflicted files
-    var confirmations = [];
-
-    // queues conflicted files for confirmation and
-    // writes non-conflicted files
-    async.each(tests, function (item, callback) {
-      if (lodash.includes(conflicted, item.name)) {
-        var temp = function(callback) {
-          var message = util.format('Overwrite %s?\n', item.name);
-          var question = { name: 'x', message: message, type: 'confirm'};
-
-          inquirer.prompt(question, function(answers) {
-            callback(null, {data: item, ans: answers.x});
-          });
-        }
-
-        confirmations.push(temp);
-      } else {
-        fs.outputFile(path.join(directory, '/test', item.name), item.test,
-          callback);
-      }
-    }, callback);
-
-    // runs confirmations of conflicted files and
-    // writes those that are confirmed for overwriting
-    async.series(confirmations, function(err, result) {
-      var filtered = lodash.filter(result, function(n){
-        return n.ans;
-      });
-
-      for (var ndx in filtered) {
-        if (filtered[ndx].ans) {
-          fs.outputFile(path.join(directory, '/test', filtered[ndx].data.name),
-            filtered[ndx].data.test);
-        }
-      }
-    });
-  } else { // Either overwrite all or none of conflicted files
-    async.each(tests, function (item, callback) {
-      if (overwrite === OVERWRITES[0]) {
-        if (!lodash.includes(conflicted, item.name)) {
-          fs.outputFile(path.join(directory, '/test', item.name), item.test,
-            callback);
-        }
-      } else if (overwrite === OVERWRITES[1]) {
-        fs.outputFile(path.join(directory, '/test', item.name), item.test,
-            callback);
-      }
-    }, callback);
-  }
-}
-
-function findConflictFiles(directory, generated) {
-  var file;
-  var test;
-  var dir = fs.readdirSync(path.join(directory, 'test'));
-  var names = [];
-
-  for (file in generated) {
-    names.push(generated[file].name);
-  }
-
-  return lodash.intersection(names, dir);
-}
-

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -28,6 +28,7 @@ var template = require('swagger-test-templates');
 var async = require('async');
 var swaggerSpec = require('../../util/spec');
 var spec = require('swagger-tools').specs.v2;
+var inquirer = require('inquirer');
 
 var FRAMEWORKS = {
   connect: { source: 'connect' },
@@ -36,6 +37,8 @@ var FRAMEWORKS = {
   restify: { source: 'connect', overlay: 'restify' },
   sails:   { source: 'sails' }
 };
+
+var OVERWRITES = ['none', 'all', 'prompt'];
 
 var ASSERTIONTYPES = ['expect', 'should', 'assert'];
 var TESTMODULES = ['supertest', 'request'];
@@ -384,11 +387,15 @@ function spawn(command, options, cwd, cb) {
 //.option('-p, --path-name [path]', 'a sepecific path of the api')
 //.option('-f, --test-module <module>', 'one of: ' + testmodules)
 //.option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
+//.option('-o, --force', 'allow overwriting of all existing test files matching those generated')
 function testGenerate(directory, options, cb) {
   var pathList = [];
   var desiredPaths = [];
   var testModule = options.testModule || TESTMODULES[0];
   var assertionFormat = options.assertionFormat || ASSERTIONTYPES[0];
+  var overwriteAll = options.force || false;
+  var conflicts;
+  directory = directory || process.cwd();
 
   findProjectFile(directory, null, function(err, projPath) {
     var projectFile;
@@ -463,17 +470,29 @@ function testGenerate(directory, options, cb) {
           };
           var finalResult = template.testGen(result, config);
 
-          //output the result
-          directory = directory || process.cwd();
-          async.each(finalResult, function (item, callback) {
-            fs.outputFile(path.join(directory, '/test', item.name), item.test, callback);
-          }, cb);
+          if (!overwriteAll) {
+            conflicts = findConflictFiles(directory, finalResult);
+
+            if (conflicts.length > 0) {
+              var message = 'Found ' + conflicts.length + ' conflicted file(s). How would you like to overwrite?'
+
+              var questions = [
+                { name: 'overwrite', message: message, type: 'list', choices: OVERWRITES }
+              ];
+
+              cli.requireAnswers(questions, function(results) {
+                  writeTestFiles(directory, finalResult, conflicts, results.overwrite, cb);
+              });
+            }
+          }
+
+          if (overwriteAll || conflicts.length === 0) {
+            writeTestFiles(directory, finalResult, null, OVERWRITES[1], cb);
+          }
         });
       });
     });
   });
-
-
 }
 
 function installDependencies(directory, message, cb) {
@@ -485,3 +504,80 @@ function installDependencies(directory, message, cb) {
     cb(null, message);
   });
 }
+
+function writeTestFiles(directory, tests, conflicted, overwrite, callback) {
+  var index;
+  var file;
+
+  if (overwrite === OVERWRITES[2]) { // prompt on conflicted files
+    var confirmations = [];
+
+    // queues conflicted files for confirmation and
+    // writes non-conflicted files
+    async.each(tests, function (item, callback) {
+      if (conflicted.indexOf(item.name) !== -1) {
+        var temp = function(callback) {
+          var message = 'Overwrite ' + item.name + '?\n';
+          var question = { name: 'x', message: message, type: 'confirm'};
+
+          inquirer.prompt(question, function(answers) {
+            callback(null, {data: item, ans: answers.x});
+          });
+        }
+
+        confirmations.push(temp);
+      } else {
+        fs.outputFile(path.join(directory, '/test', item.name), item.test,
+          callback);
+      }
+    }, callback);
+
+    // runs confirmations of conflicted files and
+    // writes those that are confirmed for overwriting
+    async.series(confirmations, function(err, result) {
+      var ndx;
+      var overwriteCount = 0;
+
+      for (ndx in result) {
+        if (result[ndx].ans) {
+          overwriteCount++;
+          fs.outputFile(path.join(directory, '/test', result[ndx].data.name),
+            result[ndx].data.test);
+        }
+      }
+
+      console.log('done overwriting ' + overwriteCount + ' file(s).');
+    });
+  } else if(overwrite === OVERWRITES[1]) { // overwrite all conflicted files
+    async.each(tests, function (item, callback) {
+      fs.outputFile(path.join(directory, '/test', item.name), item.test,
+        callback);
+    }, callback);
+  } else { // do not overwrite any conflicted file
+    async.each(tests, function (item, callback) {
+      if (conflicted.indexOf(item.name) === -1) {
+        fs.outputFile(path.join(directory, '/test', item.name), item.test,
+          callback);
+      }
+    }, callback);
+  }
+}
+
+function findConflictFiles(directory, generated) {
+  var file;
+  var test;
+  var dir = fs.readdirSync(path.join(directory, 'test'));
+  var conflictedFiles = [];
+
+  for(file in dir) {
+    for (test in generated) {
+      if (dir[file] === generated[test].name) {
+        conflictedFiles.push(dir[file]);
+        break;
+      }
+    }
+  }
+
+  return conflictedFiles;
+}
+

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -548,16 +548,16 @@ function writeTestFiles(directory, tests, conflicted, overwrite, callback) {
 
       console.log('done overwriting ' + filtered.length + ' file(s).');
     });
-  } else if(overwrite === OVERWRITES[1]) { // overwrite all conflicted files
+  } else { // Either overwrite all or none of conflicted files
     async.each(tests, function (item, callback) {
-      fs.outputFile(path.join(directory, '/test', item.name), item.test,
-        callback);
-    }, callback);
-  } else { // do not overwrite any conflicted file
-    async.each(tests, function (item, callback) {
-      if (lodash.includes(conflicted, item.name)) {
+      if (overwrite === OVERWRITES[0]) {
+        if (!lodash.includes(conflicted, item.name)) {
+          fs.outputFile(path.join(directory, '/test', item.name), item.test,
+            callback);
+        }
+      } else if (overwrite === OVERWRITES[1]) {
         fs.outputFile(path.join(directory, '/test', item.name), item.test,
-          callback);
+            callback);
       }
     }, callback);
   }

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -545,8 +545,6 @@ function writeTestFiles(directory, tests, conflicted, overwrite, callback) {
             filtered[ndx].data.test);
         }
       }
-
-      console.log('done overwriting ' + filtered.length + ' file(s).');
     });
   } else { // Either overwrite all or none of conflicted files
     async.each(tests, function (item, callback) {

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -29,6 +29,7 @@ var async = require('async');
 var swaggerSpec = require('../../util/spec');
 var spec = require('swagger-tools').specs.v2;
 var inquirer = require('inquirer');
+var lodash = require('lodash');
 
 var FRAMEWORKS = {
   connect: { source: 'connect' },
@@ -394,7 +395,6 @@ function testGenerate(directory, options, cb) {
   var testModule = options.testModule || TESTMODULES[0];
   var assertionFormat = options.assertionFormat || ASSERTIONTYPES[0];
   var overwriteAll = options.force || false;
-  var conflicts;
   directory = directory || process.cwd();
 
   findProjectFile(directory, null, function(err, projPath) {
@@ -469,12 +469,14 @@ function testGenerate(directory, options, cb) {
             assertionFormat: assertionFormat
           };
           var finalResult = template.testGen(result, config);
+          var conflicts;
 
           if (!overwriteAll) {
             conflicts = findConflictFiles(directory, finalResult);
 
             if (conflicts.length > 0) {
-              var message = 'Found ' + conflicts.length + ' conflicted file(s). How would you like to overwrite?'
+              var message = util.format('Found %d conflicted file(s). %s',
+                conflicts.length, 'How would you like to overwrite?');
 
               var questions = [
                 { name: 'overwrite', message: message, type: 'list', choices: OVERWRITES }
@@ -506,8 +508,6 @@ function installDependencies(directory, message, cb) {
 }
 
 function writeTestFiles(directory, tests, conflicted, overwrite, callback) {
-  var index;
-  var file;
 
   if (overwrite === OVERWRITES[2]) { // prompt on conflicted files
     var confirmations = [];
@@ -515,9 +515,9 @@ function writeTestFiles(directory, tests, conflicted, overwrite, callback) {
     // queues conflicted files for confirmation and
     // writes non-conflicted files
     async.each(tests, function (item, callback) {
-      if (conflicted.indexOf(item.name) !== -1) {
+      if (lodash.includes(conflicted, item.name)) {
         var temp = function(callback) {
-          var message = 'Overwrite ' + item.name + '?\n';
+          var message = util.format('Overwrite %s?\n', item.name);
           var question = { name: 'x', message: message, type: 'confirm'};
 
           inquirer.prompt(question, function(answers) {
@@ -535,18 +535,18 @@ function writeTestFiles(directory, tests, conflicted, overwrite, callback) {
     // runs confirmations of conflicted files and
     // writes those that are confirmed for overwriting
     async.series(confirmations, function(err, result) {
-      var ndx;
-      var overwriteCount = 0;
+      var filtered = lodash.filter(result, function(n){
+        return n.ans;
+      });
 
-      for (ndx in result) {
-        if (result[ndx].ans) {
-          overwriteCount++;
-          fs.outputFile(path.join(directory, '/test', result[ndx].data.name),
-            result[ndx].data.test);
+      for (var ndx in filtered) {
+        if (filtered[ndx].ans) {
+          fs.outputFile(path.join(directory, '/test', filtered[ndx].data.name),
+            filtered[ndx].data.test);
         }
       }
 
-      console.log('done overwriting ' + overwriteCount + ' file(s).');
+      console.log('done overwriting ' + filtered.length + ' file(s).');
     });
   } else if(overwrite === OVERWRITES[1]) { // overwrite all conflicted files
     async.each(tests, function (item, callback) {
@@ -555,7 +555,7 @@ function writeTestFiles(directory, tests, conflicted, overwrite, callback) {
     }, callback);
   } else { // do not overwrite any conflicted file
     async.each(tests, function (item, callback) {
-      if (conflicted.indexOf(item.name) === -1) {
+      if (lodash.includes(conflicted, item.name)) {
         fs.outputFile(path.join(directory, '/test', item.name), item.test,
           callback);
       }
@@ -567,17 +567,12 @@ function findConflictFiles(directory, generated) {
   var file;
   var test;
   var dir = fs.readdirSync(path.join(directory, 'test'));
-  var conflictedFiles = [];
+  var names = [];
 
-  for(file in dir) {
-    for (test in generated) {
-      if (dir[file] === generated[test].name) {
-        conflictedFiles.push(dir[file]);
-        break;
-      }
-    }
+  for (file in generated) {
+    names.push(generated[file].name);
   }
 
-  return conflictedFiles;
+  return lodash.intersection(names, dir);
 }
 

--- a/package.json
+++ b/package.json
@@ -18,13 +18,14 @@
     "url": "https://github.com/swagger-api/swagger-node.git"
   },
   "dependencies": {
+    "async": "^1.2.1",
     "commander": "^2.7.1",
     "connect": "^3.3.5",
     "debug": "^2.1.3",
     "fs-extra": "^0.18.0",
     "inquirer": "^0.8.2",
     "js-yaml": "^3.3.0",
-    "lodash": "^3.6.0",
+    "lodash": "^3.10.0",
     "mocha": "^2.2.1",
     "nodemon": "^1.3.7",
     "serve-static": "^1.9.2",


### PR DESCRIPTION
Additions include:
- `-o --force` flag for forced overwrite of conflicted files
- without flag, if conflicts arise, user is prompted to choose course of action for overwriting including overwriting `none`, `all`, or `prompt`, the last of which prompts the user with yes/no for each conflicted file.
